### PR TITLE
Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,12 @@ group :development, :test do
   gem 'faker'
   gem 'shoulda-matchers', '~> 3.0', require: false
   gem 'database_cleaner'
+  # add dependency for faraday
+  gem 'net-http'
 end
 
 group :development do
+  gem 'pry-rails'
   gem 'listen', '~> 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     database_cleaner (2.0.1)
@@ -170,6 +171,15 @@ GEM
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
       ttfunk (~> 1.7)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -261,6 +271,8 @@ GEM
     ruby2_keywords (0.0.4)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
+    spoon (0.0.6)
+      ffi
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -318,6 +330,7 @@ DEPENDENCIES
   notion (~> 1.1, >= 1.1.4)
   pg (>= 0.18, < 2.0)
   prawn
+  pry-rails
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
     net-ftp (0.1.2)
       net-protocol
       time
+    net-http (0.1.1)
+      net-protocol
+      uri
     net-protocol (0.1.0)
     netrc (0.11.0)
     nio4r (2.5.7)
@@ -227,24 +230,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rest-client (2.1.0-x64-mingw32)
-      ffi (~> 1.9)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rest-client (2.1.0-x86-mingw32)
-      ffi (~> 1.9)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rest-client (2.1.0-x86-mswin32)
-      ffi (~> 1.9)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -291,14 +276,13 @@ GEM
     ttfunk (1.7.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2021.1)
-      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf (0.1.4-java)
     unf_ext (0.0.7.7)
     unf_ext (0.0.7.7-x64-mingw32)
     unf_ext (0.0.7.7-x86-mingw32)
+    uri (0.10.1)
     websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.4-java)
@@ -327,6 +311,7 @@ DEPENDENCIES
   json_matchers
   jsonapi-serializer
   listen (~> 3.2)
+  net-http
   notion (~> 1.1, >= 1.1.4)
   pg (>= 0.18, < 2.0)
   prawn


### PR DESCRIPTION
The pry gem is added for debugging the application.
When the application is written, the gem can be removed.
The net-http gem is added temporarily until the backward compatibility problem with version 2.5 is resolved
https://github.com/lostisland/faraday-net_http/pull/5